### PR TITLE
[#6] Add user profile view and edit flow

### DIFF
--- a/backend/src/main/java/pl/platformatreningowa/profile/boundary/ProfileController.java
+++ b/backend/src/main/java/pl/platformatreningowa/profile/boundary/ProfileController.java
@@ -1,0 +1,45 @@
+package pl.platformatreningowa.profile.boundary;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pl.platformatreningowa.profile.control.ProfileService;
+import pl.platformatreningowa.profile.entity.ChangePasswordRequest;
+import pl.platformatreningowa.profile.entity.UpdateProfileRequest;
+import pl.platformatreningowa.profile.entity.UserProfile;
+
+@RestController
+@RequestMapping("/api/auth/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserProfile> getProfile(@RequestHeader("Authorization") String authorization) {
+        return ResponseEntity.ok(profileService.getProfile(authorization));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<UserProfile> updateProfile(
+            @RequestHeader("Authorization") String authorization,
+            @Valid @RequestBody UpdateProfileRequest request) {
+        return ResponseEntity.ok(profileService.updateProfile(authorization, request));
+    }
+
+    @PutMapping("/me/password")
+    public ResponseEntity<Void> changePassword(
+            @RequestHeader("Authorization") String authorization,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        profileService.changePassword(authorization, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/pl/platformatreningowa/profile/control/ProfileService.java
+++ b/backend/src/main/java/pl/platformatreningowa/profile/control/ProfileService.java
@@ -1,0 +1,95 @@
+package pl.platformatreningowa.profile.control;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pl.platformatreningowa.auth.control.JwtService;
+import pl.platformatreningowa.auth.control.UserRepository;
+import pl.platformatreningowa.auth.entity.UserEntity;
+import pl.platformatreningowa.profile.entity.ChangePasswordRequest;
+import pl.platformatreningowa.profile.entity.UpdateProfileRequest;
+import pl.platformatreningowa.profile.entity.UserProfile;
+import pl.platformatreningowa.shared.entity.UnauthorizedException;
+import pl.platformatreningowa.shared.entity.ValidationException;
+
+@Service
+public class ProfileService {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    public ProfileService(UserRepository userRepository, JwtService jwtService, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UserProfile getProfile(String authorizationHeader) {
+        return toProfile(getUserFromAuthorizationHeader(authorizationHeader));
+    }
+
+    public UserProfile updateProfile(String authorizationHeader, UpdateProfileRequest request) {
+        UserEntity user = getUserFromAuthorizationHeader(authorizationHeader);
+        user.setWeight(request.weight());
+        user.setTrainingDays(String.join(",", request.trainingDays()));
+        user.setGoal(request.goal());
+        user.setFoodIntolerances(blankToNull(request.foodIntolerances()));
+        user.setAvailableEquipment(String.join(",", request.availableEquipment()));
+        return toProfile(userRepository.save(user));
+    }
+
+    public void changePassword(String authorizationHeader, ChangePasswordRequest request) {
+        UserEntity user = getUserFromAuthorizationHeader(authorizationHeader);
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
+            throw new ValidationException("Nieprawidłowe aktualne hasło.");
+        }
+        if (!request.newPassword().equals(request.confirmNewPassword())) {
+            throw new ValidationException("Nowe hasła muszą być identyczne.");
+        }
+        user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+    }
+
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private UserEntity getUserFromAuthorizationHeader(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new UnauthorizedException("Missing or invalid Authorization header");
+        }
+        try {
+            Long userId = jwtService.extractUserId(authorizationHeader.substring(7).trim());
+            return userRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("User for token was not found"));
+        } catch (RuntimeException exception) {
+            throw new UnauthorizedException("Invalid or expired token");
+        }
+    }
+
+    private UserProfile toProfile(UserEntity user) {
+        return new UserProfile(
+                user.getEmail(),
+                user.getAge(),
+                user.getSex(),
+                user.getWeight(),
+                user.getHeight(),
+                user.getBodyType(),
+                user.getActivityHistory(),
+                splitCsv(user.getTrainingDays()),
+                user.getGoal(),
+                user.getTargetDistance(),
+                user.getTargetTime(),
+                user.getFoodIntolerances(),
+                splitCsv(user.getAvailableEquipment())
+        );
+    }
+
+    private List<String> splitCsv(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(",")).map(String::trim).filter(item -> !item.isEmpty()).toList();
+    }
+}

--- a/backend/src/main/java/pl/platformatreningowa/profile/entity/ChangePasswordRequest.java
+++ b/backend/src/main/java/pl/platformatreningowa/profile/entity/ChangePasswordRequest.java
@@ -1,0 +1,11 @@
+package pl.platformatreningowa.profile.entity;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank String currentPassword,
+        @NotBlank @Size(min = 8, max = 72) String newPassword,
+        @NotBlank @Size(min = 8, max = 72) String confirmNewPassword
+) {
+}

--- a/backend/src/main/java/pl/platformatreningowa/profile/entity/UpdateProfileRequest.java
+++ b/backend/src/main/java/pl/platformatreningowa/profile/entity/UpdateProfileRequest.java
@@ -1,0 +1,20 @@
+package pl.platformatreningowa.profile.entity;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record UpdateProfileRequest(
+        @NotNull @DecimalMin("30.0") @DecimalMax("300.0") BigDecimal weight,
+        @NotEmpty @Size(max = 7) List<@Pattern(regexp = "MON|TUE|WED|THU|FRI|SAT|SUN") String> trainingDays,
+        @NotBlank @Pattern(regexp = "schudnąć|poprawić kondycję|biegać szybciej|zacząć się ruszać|przygotowanie do zawodów") String goal,
+        @Size(max = 500) String foodIntolerances,
+        @NotEmpty @Size(max = 4) List<@Pattern(regexp = "nic|hantle|gumy|siłownia") String> availableEquipment
+) {
+}

--- a/backend/src/main/java/pl/platformatreningowa/profile/entity/UserProfile.java
+++ b/backend/src/main/java/pl/platformatreningowa/profile/entity/UserProfile.java
@@ -1,0 +1,21 @@
+package pl.platformatreningowa.profile.entity;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record UserProfile(
+        String email,
+        Integer age,
+        String sex,
+        BigDecimal weight,
+        BigDecimal height,
+        String bodyType,
+        String activityHistory,
+        List<String> trainingDays,
+        String goal,
+        BigDecimal targetDistance,
+        String targetTime,
+        String foodIntolerances,
+        List<String> availableEquipment
+) {
+}

--- a/backend/src/test/java/pl/platformatreningowa/profile/boundary/ProfileControllerTest.java
+++ b/backend/src/test/java/pl/platformatreningowa/profile/boundary/ProfileControllerTest.java
@@ -1,0 +1,93 @@
+package pl.platformatreningowa.profile.boundary;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import pl.platformatreningowa.profile.control.ProfileService;
+import pl.platformatreningowa.profile.entity.UserProfile;
+import pl.platformatreningowa.shared.boundary.ApiExceptionHandler;
+import pl.platformatreningowa.shared.control.SecurityConfig;
+import pl.platformatreningowa.shared.entity.ValidationException;
+
+@WebMvcTest(ProfileController.class)
+@Import({SecurityConfig.class, ApiExceptionHandler.class})
+class ProfileControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private ProfileService profileService;
+
+    @Test
+    void getProfileReturnsUserData() throws Exception {
+        given(profileService.getProfile("Bearer test-token")).willReturn(new UserProfile(
+                "runner@example.com", 31, "mężczyzna", new BigDecimal("76.50"), new BigDecimal("182.00"),
+                "średni", "regularnie", List.of("MON", "WED"), "biegać szybciej",
+                new BigDecimal("10.00"), "50:00", "laktoza", List.of("gumy")
+        ));
+
+        mockMvc.perform(get("/api/auth/profile/me").header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("runner@example.com"))
+                .andExpect(jsonPath("$.age").value(31))
+                .andExpect(jsonPath("$.trainingDays[0]").value("MON"));
+    }
+
+    @Test
+    void updateProfileReturnsUpdatedData() throws Exception {
+        given(profileService.updateProfile(eq("Bearer test-token"), any())).willReturn(new UserProfile(
+                "runner@example.com", 31, "mężczyzna", new BigDecimal("80.00"), new BigDecimal("182.00"),
+                "średni", "regularnie", List.of("TUE", "THU"), "poprawić kondycję",
+                new BigDecimal("10.00"), "50:00", "gluten", List.of("hantle")
+        ));
+
+        mockMvc.perform(put("/api/auth/profile/me")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"weight":80.0,"trainingDays":["TUE","THU"],"goal":"poprawić kondycję",
+                                 "foodIntolerances":"gluten","availableEquipment":["hantle"]}"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weight").value(80.0))
+                .andExpect(jsonPath("$.goal").value("poprawić kondycję"));
+    }
+
+    @Test
+    void changePasswordReturns204() throws Exception {
+        doNothing().when(profileService).changePassword(eq("Bearer test-token"), any());
+
+        mockMvc.perform(put("/api/auth/profile/me/password")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"currentPassword":"oldPass123","newPassword":"newPass123","confirmNewPassword":"newPass123"}"""))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void changePasswordReturns400OnWrongCurrentPassword() throws Exception {
+        doThrow(new ValidationException("Nieprawidłowe aktualne hasło."))
+                .when(profileService).changePassword(eq("Bearer test-token"), any());
+
+        mockMvc.perform(put("/api/auth/profile/me/password")
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"currentPassword":"wrong","newPassword":"newPass123","confirmNewPassword":"newPass123"}"""))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/pl/platformatreningowa/profile/control/ProfileServiceTest.java
+++ b/backend/src/test/java/pl/platformatreningowa/profile/control/ProfileServiceTest.java
@@ -1,0 +1,134 @@
+package pl.platformatreningowa.profile.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import pl.platformatreningowa.auth.control.JwtService;
+import pl.platformatreningowa.auth.control.UserRepository;
+import pl.platformatreningowa.auth.entity.UserEntity;
+import pl.platformatreningowa.profile.entity.ChangePasswordRequest;
+import pl.platformatreningowa.profile.entity.UpdateProfileRequest;
+import pl.platformatreningowa.profile.entity.UserProfile;
+import pl.platformatreningowa.shared.entity.UnauthorizedException;
+import pl.platformatreningowa.shared.entity.ValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private JwtService jwtService;
+    @Mock private PasswordEncoder passwordEncoder;
+    @InjectMocks private ProfileService service;
+
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = new UserEntity();
+        user.setId(7L);
+        user.setEmail("runner@example.com");
+        user.setPasswordHash("hashed-password");
+        user.setAge(31);
+        user.setSex("mężczyzna");
+        user.setWeight(new BigDecimal("76.50"));
+        user.setHeight(new BigDecimal("182.00"));
+        user.setBodyType("średni");
+        user.setActivityHistory("regularnie");
+        user.setTrainingDays("MON,WED,SAT");
+        user.setGoal("biegać szybciej");
+        user.setTargetDistance(new BigDecimal("10.00"));
+        user.setTargetTime("50:00");
+        user.setFoodIntolerances("laktoza");
+        user.setAvailableEquipment("gumy,siłownia");
+    }
+
+    @Test
+    void returnsUserProfile() {
+        given(jwtService.extractUserId("token")).willReturn(7L);
+        given(userRepository.findById(7L)).willReturn(Optional.of(user));
+
+        UserProfile profile = service.getProfile("Bearer token");
+
+        assertThat(profile.email()).isEqualTo("runner@example.com");
+        assertThat(profile.age()).isEqualTo(31);
+        assertThat(profile.trainingDays()).containsExactly("MON", "WED", "SAT");
+        assertThat(profile.availableEquipment()).containsExactly("gumy", "siłownia");
+        assertThat(profile.foodIntolerances()).isEqualTo("laktoza");
+    }
+
+    @Test
+    void updatesEditableFields() {
+        given(jwtService.extractUserId("token")).willReturn(7L);
+        given(userRepository.findById(7L)).willReturn(Optional.of(user));
+        given(userRepository.save(any(UserEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        UserProfile profile = service.updateProfile("Bearer token", new UpdateProfileRequest(
+                new BigDecimal("80.00"), List.of("TUE", "THU"), "poprawić kondycję", "gluten", List.of("hantle")
+        ));
+
+        assertThat(profile.weight()).isEqualByComparingTo(new BigDecimal("80.00"));
+        assertThat(profile.trainingDays()).containsExactly("TUE", "THU");
+        assertThat(profile.goal()).isEqualTo("poprawić kondycję");
+        assertThat(profile.foodIntolerances()).isEqualTo("gluten");
+        assertThat(profile.availableEquipment()).containsExactly("hantle");
+        assertThat(profile.age()).isEqualTo(31);
+        assertThat(profile.sex()).isEqualTo("mężczyzna");
+    }
+
+    @Test
+    void changesPasswordSuccessfully() {
+        given(jwtService.extractUserId("token")).willReturn(7L);
+        given(userRepository.findById(7L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("oldPass123", "hashed-password")).willReturn(true);
+        given(passwordEncoder.encode("newPass123")).willReturn("new-hashed");
+
+        service.changePassword("Bearer token", new ChangePasswordRequest("oldPass123", "newPass123", "newPass123"));
+
+        assertThat(user.getPasswordHash()).isEqualTo("new-hashed");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void rejectsWrongCurrentPassword() {
+        given(jwtService.extractUserId("token")).willReturn(7L);
+        given(userRepository.findById(7L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong", "hashed-password")).willReturn(false);
+
+        assertThatThrownBy(() -> service.changePassword("Bearer token",
+                new ChangePasswordRequest("wrong", "newPass123", "newPass123")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Nieprawidłowe aktualne hasło.");
+    }
+
+    @Test
+    void rejectsMismatchedNewPasswords() {
+        given(jwtService.extractUserId("token")).willReturn(7L);
+        given(userRepository.findById(7L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("oldPass123", "hashed-password")).willReturn(true);
+
+        assertThatThrownBy(() -> service.changePassword("Bearer token",
+                new ChangePasswordRequest("oldPass123", "newPass123", "different")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("Nowe hasła muszą być identyczne.");
+    }
+
+    @Test
+    void rejectsMissingBearerToken() {
+        assertThatThrownBy(() -> service.getProfile(null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Missing or invalid Authorization header");
+    }
+}

--- a/mobile/lib/app/platforma_treningowa_app.dart
+++ b/mobile/lib/app/platforma_treningowa_app.dart
@@ -3,10 +3,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../business/auth/boundary/auth_bloc.dart';
 import '../business/onboarding/entity/onboarding_profile.dart';
+import '../business/profile/boundary/profile_bloc.dart';
+import '../business/profile/control/profile_repository.dart';
 import 'screens/auth_screen.dart';
 import 'screens/dashboard_screen.dart';
 import 'screens/legal_consent_screen.dart';
 import 'screens/onboarding_screen.dart';
+import 'screens/profile_screen.dart';
 
 class PlatformaTreningowaApp extends StatefulWidget {
   const PlatformaTreningowaApp({super.key});
@@ -19,6 +22,7 @@ class _PlatformaTreningowaAppState extends State<PlatformaTreningowaApp> {
   DateTime? acceptedAt;
   OnboardingProfile? profile;
   bool editingOnboarding = false;
+  bool showingProfile = false;
 
   @override
   Widget build(BuildContext context) {
@@ -40,12 +44,32 @@ class _PlatformaTreningowaAppState extends State<PlatformaTreningowaApp> {
           if (authResult != null && (!authResult.onboardingCompleted || editingOnboarding)) {
             return OnboardingScreen(
               onCompleted: (savedProfile) {
+                context.read<ProfileRepository>().setProfile(savedProfile);
                 setState(() {
                   profile = savedProfile;
                   editingOnboarding = false;
+                  showingProfile = false;
                 });
                 context.read<AuthBloc>().add(const AuthOnboardingCompleted());
               },
+            );
+          }
+          if (authResult != null && authResult.onboardingCompleted && showingProfile) {
+            return BlocProvider(
+              create: (context) => ProfileBloc(context.read<ProfileRepository>()),
+              child: ProfileScreen(
+                email: authResult.email,
+                onBack: () => setState(() => showingProfile = false),
+                onLogout: () {
+                  setState(() {
+                    acceptedAt = null;
+                    profile = null;
+                    editingOnboarding = false;
+                    showingProfile = false;
+                  });
+                  context.read<AuthBloc>().add(const AuthLoggedOut());
+                },
+              ),
             );
           }
           if (authResult != null && authResult.onboardingCompleted) {
@@ -53,6 +77,16 @@ class _PlatformaTreningowaAppState extends State<PlatformaTreningowaApp> {
               authResult: authResult,
               profile: profile ?? const OnboardingProfile(onboardingCompleted: true),
               onEdit: () => setState(() => editingOnboarding = true),
+              onOpenProfile: () => setState(() => showingProfile = true),
+              onLogout: () {
+                setState(() {
+                  acceptedAt = null;
+                  profile = null;
+                  editingOnboarding = false;
+                  showingProfile = false;
+                });
+                context.read<AuthBloc>().add(const AuthLoggedOut());
+              },
             );
           }
           return AuthScreen(acceptedAt: acceptedAt, authResultOverride: authResult);

--- a/mobile/lib/app/screens/dashboard_screen.dart
+++ b/mobile/lib/app/screens/dashboard_screen.dart
@@ -4,28 +4,51 @@ import '../../business/auth/entity/auth_result.dart';
 import '../../business/onboarding/entity/onboarding_profile.dart';
 
 class DashboardScreen extends StatelessWidget {
-  const DashboardScreen({super.key, required this.authResult, required this.profile, required this.onEdit});
+  const DashboardScreen({
+    super.key,
+    required this.authResult,
+    required this.profile,
+    required this.onEdit,
+    required this.onOpenProfile,
+    required this.onLogout,
+  });
 
   final AuthResult authResult;
   final OnboardingProfile profile;
   final VoidCallback onEdit;
+  final VoidCallback onOpenProfile;
+  final VoidCallback onLogout;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Dashboard')),
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: [
+          TextButton(onPressed: onLogout, child: const Text('Wyloguj')),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Text('Zalogowano jako ${authResult.email}. Redirect: ${authResult.redirectTo}'),
-          const SizedBox(height: 16),
-          Text('Wiek: ${profile.age}'),
-          Text('Cel: ${profile.goal}'),
-          Text('Dni: ${profile.trainingDays.join(', ')}'),
-          Text('Sprzęt: ${profile.availableEquipment.join(', ')}'),
-          const SizedBox(height: 16),
-          OutlinedButton(onPressed: onEdit, child: const Text('Edytuj onboarding')),
-        ]),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Zalogowano jako ${authResult.email}. Redirect: ${authResult.redirectTo}'),
+            const SizedBox(height: 16),
+            Text('Wiek: ${profile.age ?? '-'}'),
+            Text('Cel: ${profile.goal.isEmpty ? '-' : profile.goal}'),
+            Text('Dni: ${profile.trainingDays.isEmpty ? '-' : profile.trainingDays.join(', ')}'),
+            Text('Sprzęt: ${profile.availableEquipment.isEmpty ? '-' : profile.availableEquipment.join(', ')}'),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(child: OutlinedButton(onPressed: onEdit, child: const Text('Edytuj onboarding'))),
+                const SizedBox(width: 12),
+                Expanded(child: FilledButton(onPressed: onOpenProfile, child: const Text('Mój profil'))),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/app/screens/profile_screen.dart
+++ b/mobile/lib/app/screens/profile_screen.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../business/onboarding/entity/onboarding_profile.dart';
+import '../../business/profile/boundary/profile_bloc.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key, required this.email, required this.onBack, required this.onLogout});
+
+  final String email;
+  final VoidCallback onBack;
+  final VoidCallback onLogout;
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  final weightController = TextEditingController();
+  final foodController = TextEditingController();
+  final currentPasswordController = TextEditingController();
+  final newPasswordController = TextEditingController();
+  final confirmPasswordController = TextEditingController();
+
+  static const allDays = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+  static const goalOptions = ['schudnąć', 'poprawić kondycję', 'biegać szybciej', 'zacząć się ruszać', 'przygotowanie do zawodów'];
+  static const equipmentOptions = ['nic', 'hantle', 'gumy', 'siłownia'];
+  static const dayLabels = {
+    'MON': 'Pon',
+    'TUE': 'Wt',
+    'WED': 'Śr',
+    'THU': 'Czw',
+    'FRI': 'Pt',
+    'SAT': 'Sob',
+    'SUN': 'Ndz',
+  };
+
+  bool editing = false;
+  bool changingPassword = false;
+  List<String> trainingDays = const [];
+  List<String> availableEquipment = const [];
+  String goal = '';
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<ProfileBloc>().add(const ProfileLoaded());
+  }
+
+  @override
+  void dispose() {
+    weightController.dispose();
+    foodController.dispose();
+    currentPasswordController.dispose();
+    newPasswordController.dispose();
+    confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileBloc, ProfileState>(
+      builder: (context, state) {
+        final profile = state.profile;
+        if (profile != null && !editing) {
+          weightController.text = profile.weight;
+          foodController.text = profile.foodIntolerances;
+          trainingDays = List.of(profile.trainingDays);
+          availableEquipment = List.of(profile.availableEquipment);
+          goal = profile.goal;
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Mój profil'),
+            leading: IconButton(onPressed: widget.onBack, icon: const Icon(Icons.arrow_back)),
+            actions: [
+              TextButton(onPressed: widget.onLogout, child: const Text('Wyloguj')),
+            ],
+          ),
+          body: state.isLoading && profile == null
+              ? const Center(child: CircularProgressIndicator())
+              : profile == null
+                  ? Center(child: Text(state.errorMessage ?? 'Nie udało się załadować profilu.'))
+                  : ListView(
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        if (state.successMessage != null) ...[
+                          _MessageBox(message: state.successMessage!, isError: false),
+                          const SizedBox(height: 12),
+                        ],
+                        if (state.errorMessage != null) ...[
+                          _MessageBox(message: state.errorMessage!, isError: true),
+                          const SizedBox(height: 12),
+                        ],
+                        if (!editing) ...[
+                          _ProfileReadOnlyCard(email: widget.email, profile: profile),
+                          const SizedBox(height: 16),
+                          FilledButton(onPressed: () => setState(() => editing = true), child: const Text('Edytuj profil')),
+                        ] else ...[
+                          TextField(
+                            controller: weightController,
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(labelText: 'Waga (kg)', border: OutlineInputBorder()),
+                          ),
+                          const SizedBox(height: 12),
+                          DropdownButtonFormField<String>(
+                            initialValue: goal.isEmpty ? null : goal,
+                            decoration: const InputDecoration(labelText: 'Cel', border: OutlineInputBorder()),
+                            items: goalOptions.map((item) => DropdownMenuItem(value: item, child: Text(item))).toList(),
+                            onChanged: (value) => setState(() => goal = value ?? ''),
+                          ),
+                          const SizedBox(height: 12),
+                          const Text('Dni treningowe'),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: allDays.map((day) => FilterChip(
+                              label: Text(dayLabels[day] ?? day),
+                              selected: trainingDays.contains(day),
+                              onSelected: (_) => setState(() {
+                                trainingDays = trainingDays.contains(day)
+                                    ? (List.of(trainingDays)..remove(day))
+                                    : [...trainingDays, day];
+                              }),
+                            )).toList(),
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: foodController,
+                            maxLines: 3,
+                            decoration: const InputDecoration(labelText: 'Nietolerancje pokarmowe', border: OutlineInputBorder()),
+                          ),
+                          const SizedBox(height: 12),
+                          const Text('Dostępny sprzęt'),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: equipmentOptions.map((item) => FilterChip(
+                              label: Text(item),
+                              selected: availableEquipment.contains(item),
+                              onSelected: (_) => setState(() {
+                                availableEquipment = availableEquipment.contains(item)
+                                    ? (List.of(availableEquipment)..remove(item))
+                                    : [...availableEquipment, item];
+                              }),
+                            )).toList(),
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: FilledButton(
+                                  onPressed: state.isSaving
+                                      ? null
+                                      : () => context.read<ProfileBloc>().add(ProfileUpdateSubmitted(
+                                            weight: weightController.text,
+                                            trainingDays: trainingDays,
+                                            goal: goal,
+                                            foodIntolerances: foodController.text,
+                                            availableEquipment: availableEquipment,
+                                          )),
+                                  child: Text(state.isSaving ? 'Zapisywanie...' : 'Zapisz'),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: OutlinedButton(
+                                  onPressed: () => setState(() => editing = false),
+                                  child: const Text('Anuluj'),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                        const SizedBox(height: 24),
+                        const Divider(),
+                        const SizedBox(height: 8),
+                        const Text('Zmiana hasła', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+                        const SizedBox(height: 12),
+                        if (state.passwordSuccessMessage != null) ...[
+                          _MessageBox(message: state.passwordSuccessMessage!, isError: false),
+                          const SizedBox(height: 12),
+                        ],
+                        if (state.passwordErrorMessage != null) ...[
+                          _MessageBox(message: state.passwordErrorMessage!, isError: true),
+                          const SizedBox(height: 12),
+                        ],
+                        if (!changingPassword)
+                          OutlinedButton(
+                            onPressed: () => setState(() => changingPassword = true),
+                            child: const Text('Zmień hasło'),
+                          )
+                        else ...[
+                          TextField(
+                            controller: currentPasswordController,
+                            obscureText: true,
+                            decoration: const InputDecoration(labelText: 'Aktualne hasło', border: OutlineInputBorder()),
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: newPasswordController,
+                            obscureText: true,
+                            decoration: const InputDecoration(labelText: 'Nowe hasło', border: OutlineInputBorder()),
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: confirmPasswordController,
+                            obscureText: true,
+                            decoration: const InputDecoration(labelText: 'Powtórz nowe hasło', border: OutlineInputBorder()),
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: FilledButton.tonal(
+                                  onPressed: state.isSaving
+                                      ? null
+                                      : () => context.read<ProfileBloc>().add(ProfilePasswordChangeSubmitted(
+                                            currentPassword: currentPasswordController.text,
+                                            newPassword: newPasswordController.text,
+                                            confirmNewPassword: confirmPasswordController.text,
+                                          )),
+                                  child: const Text('Zapisz nowe hasło'),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: OutlinedButton(
+                                  onPressed: () => setState(() => changingPassword = false),
+                                  child: const Text('Anuluj'),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    ),
+        );
+      },
+    );
+  }
+}
+
+class _ProfileReadOnlyCard extends StatelessWidget {
+  const _ProfileReadOnlyCard({required this.email, required this.profile});
+
+  final String email;
+  final OnboardingProfile profile;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Email: $email'),
+            Text('Wiek: ${profile.age ?? '-'}'),
+            Text('Płeć: ${profile.sex.isEmpty ? '-' : profile.sex}'),
+            Text('Waga: ${profile.weight.isEmpty ? '-' : '${profile.weight} kg'}'),
+            Text('Wzrost: ${profile.height.isEmpty ? '-' : '${profile.height} cm'}'),
+            Text('Sylwetka: ${profile.bodyType.isEmpty ? '-' : profile.bodyType}'),
+            Text('Aktywność: ${profile.activityHistory.isEmpty ? '-' : profile.activityHistory}'),
+            Text('Cel: ${profile.goal.isEmpty ? '-' : profile.goal}'),
+            Text('Dni treningowe: ${profile.trainingDays.isEmpty ? '-' : profile.trainingDays.join(', ')}'),
+            Text('Sprzęt: ${profile.availableEquipment.isEmpty ? '-' : profile.availableEquipment.join(', ')}'),
+            Text('Nietolerancje: ${profile.foodIntolerances.isEmpty ? 'brak' : profile.foodIntolerances}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageBox extends StatelessWidget {
+  const _MessageBox({required this.message, required this.isError});
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isError ? scheme.errorContainer : scheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(message, style: TextStyle(color: isError ? scheme.onErrorContainer : scheme.onPrimaryContainer)),
+    );
+  }
+}

--- a/mobile/lib/business/auth/boundary/auth_bloc.dart
+++ b/mobile/lib/business/auth/boundary/auth_bloc.dart
@@ -13,6 +13,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthSubmitted>(_onSubmitted);
     on<AuthLegalConsentsAccepted>(_onLegalConsentsAccepted);
     on<AuthOnboardingCompleted>(_onOnboardingCompleted);
+    on<AuthLoggedOut>(_onLoggedOut);
   }
 
   final AuthRepository _repository;
@@ -49,6 +50,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     final authResult = state.authResult;
     if (authResult == null) return;
     emit(state.copyWith(authResult: authResult.copyWith(onboardingCompleted: true, redirectTo: '/dashboard'), clearError: true));
+  }
+
+  void _onLoggedOut(AuthLoggedOut event, Emitter<AuthState> emit) {
+    emit(const AuthState.initial());
   }
 
   String? _validate(AuthSubmitted event, AuthMode mode) {

--- a/mobile/lib/business/auth/entity/auth_event.dart
+++ b/mobile/lib/business/auth/entity/auth_event.dart
@@ -34,3 +34,7 @@ final class AuthLegalConsentsAccepted extends AuthEvent {
 final class AuthOnboardingCompleted extends AuthEvent {
   const AuthOnboardingCompleted();
 }
+
+final class AuthLoggedOut extends AuthEvent {
+  const AuthLoggedOut();
+}

--- a/mobile/lib/business/profile/boundary/profile_bloc.dart
+++ b/mobile/lib/business/profile/boundary/profile_bloc.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../onboarding/entity/onboarding_profile.dart';
+import '../control/profile_repository.dart';
+
+part '../entity/profile_event.dart';
+part '../entity/profile_state.dart';
+
+class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
+  ProfileBloc(this._repository) : super(const ProfileState.initial()) {
+    on<ProfileLoaded>(_onLoaded);
+    on<ProfileUpdateSubmitted>(_onUpdateSubmitted);
+    on<ProfilePasswordChangeSubmitted>(_onPasswordChangeSubmitted);
+  }
+
+  final ProfileRepository _repository;
+
+  Future<void> _onLoaded(ProfileLoaded event, Emitter<ProfileState> emit) async {
+    emit(state.copyWith(isLoading: true, clearError: true));
+    try {
+      final profile = await _repository.loadProfile();
+      emit(state.copyWith(profile: profile, isLoading: false));
+    } catch (error) {
+      emit(state.copyWith(isLoading: false, errorMessage: error.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onUpdateSubmitted(ProfileUpdateSubmitted event, Emitter<ProfileState> emit) async {
+    emit(state.copyWith(isSaving: true, clearError: true, clearSuccess: true));
+    try {
+      final profile = await _repository.updateProfile(
+        weight: event.weight,
+        trainingDays: event.trainingDays,
+        goal: event.goal,
+        foodIntolerances: event.foodIntolerances,
+        availableEquipment: event.availableEquipment,
+      );
+      emit(state.copyWith(profile: profile, isSaving: false, successMessage: 'Profil zaktualizowany.'));
+    } catch (error) {
+      emit(state.copyWith(isSaving: false, errorMessage: error.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+
+  Future<void> _onPasswordChangeSubmitted(ProfilePasswordChangeSubmitted event, Emitter<ProfileState> emit) async {
+    emit(state.copyWith(isSaving: true, clearPasswordError: true, clearPasswordSuccess: true));
+    try {
+      await _repository.changePassword(
+        currentPassword: event.currentPassword,
+        newPassword: event.newPassword,
+        confirmNewPassword: event.confirmNewPassword,
+      );
+      emit(state.copyWith(isSaving: false, passwordSuccessMessage: 'Hasło zostało zmienione.'));
+    } catch (error) {
+      emit(state.copyWith(isSaving: false, passwordErrorMessage: error.toString().replaceFirst('Exception: ', '')));
+    }
+  }
+}

--- a/mobile/lib/business/profile/control/profile_repository.dart
+++ b/mobile/lib/business/profile/control/profile_repository.dart
@@ -1,0 +1,49 @@
+import '../../onboarding/entity/onboarding_profile.dart';
+
+class ProfileRepository {
+  OnboardingProfile _profile = const OnboardingProfile(onboardingCompleted: true);
+  String _password = 'password123';
+
+  Future<OnboardingProfile> loadProfile() async {
+    return Future<OnboardingProfile>.delayed(const Duration(milliseconds: 100), () => _profile);
+  }
+
+  Future<OnboardingProfile> updateProfile({
+    required String weight,
+    required List<String> trainingDays,
+    required String goal,
+    required String foodIntolerances,
+    required List<String> availableEquipment,
+  }) async {
+    _profile = _profile.copyWith(
+      weight: weight,
+      trainingDays: trainingDays,
+      goal: goal,
+      foodIntolerances: foodIntolerances,
+      availableEquipment: availableEquipment,
+    );
+    return Future<OnboardingProfile>.delayed(const Duration(milliseconds: 100), () => _profile);
+  }
+
+  Future<void> changePassword({
+    required String currentPassword,
+    required String newPassword,
+    required String confirmNewPassword,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    if (currentPassword != _password) {
+      throw Exception('Nieprawidłowe aktualne hasło.');
+    }
+    if (newPassword != confirmNewPassword) {
+      throw Exception('Nowe hasła muszą być identyczne.');
+    }
+    if (newPassword.length < 8) {
+      throw Exception('Nowe hasło musi mieć co najmniej 8 znaków.');
+    }
+    _password = newPassword;
+  }
+
+  void setProfile(OnboardingProfile profile) {
+    _profile = profile;
+  }
+}

--- a/mobile/lib/business/profile/entity/profile_event.dart
+++ b/mobile/lib/business/profile/entity/profile_event.dart
@@ -1,0 +1,46 @@
+part of '../boundary/profile_bloc.dart';
+
+sealed class ProfileEvent extends Equatable {
+  const ProfileEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+final class ProfileLoaded extends ProfileEvent {
+  const ProfileLoaded();
+}
+
+final class ProfileUpdateSubmitted extends ProfileEvent {
+  const ProfileUpdateSubmitted({
+    required this.weight,
+    required this.trainingDays,
+    required this.goal,
+    required this.foodIntolerances,
+    required this.availableEquipment,
+  });
+
+  final String weight;
+  final List<String> trainingDays;
+  final String goal;
+  final String foodIntolerances;
+  final List<String> availableEquipment;
+
+  @override
+  List<Object?> get props => [weight, trainingDays, goal, foodIntolerances, availableEquipment];
+}
+
+final class ProfilePasswordChangeSubmitted extends ProfileEvent {
+  const ProfilePasswordChangeSubmitted({
+    required this.currentPassword,
+    required this.newPassword,
+    required this.confirmNewPassword,
+  });
+
+  final String currentPassword;
+  final String newPassword;
+  final String confirmNewPassword;
+
+  @override
+  List<Object?> get props => [currentPassword, newPassword, confirmNewPassword];
+}

--- a/mobile/lib/business/profile/entity/profile_state.dart
+++ b/mobile/lib/business/profile/entity/profile_state.dart
@@ -1,0 +1,50 @@
+part of '../boundary/profile_bloc.dart';
+
+class ProfileState extends Equatable {
+  const ProfileState({
+    this.profile,
+    this.isLoading = false,
+    this.isSaving = false,
+    this.errorMessage,
+    this.successMessage,
+    this.passwordSuccessMessage,
+    this.passwordErrorMessage,
+  });
+
+  const ProfileState.initial() : this(isLoading: true);
+
+  final OnboardingProfile? profile;
+  final bool isLoading;
+  final bool isSaving;
+  final String? errorMessage;
+  final String? successMessage;
+  final String? passwordSuccessMessage;
+  final String? passwordErrorMessage;
+
+  ProfileState copyWith({
+    OnboardingProfile? profile,
+    bool? isLoading,
+    bool? isSaving,
+    String? errorMessage,
+    bool clearError = false,
+    String? successMessage,
+    bool clearSuccess = false,
+    String? passwordSuccessMessage,
+    bool clearPasswordSuccess = false,
+    String? passwordErrorMessage,
+    bool clearPasswordError = false,
+  }) {
+    return ProfileState(
+      profile: profile ?? this.profile,
+      isLoading: isLoading ?? this.isLoading,
+      isSaving: isSaving ?? this.isSaving,
+      errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
+      successMessage: clearSuccess ? null : successMessage ?? this.successMessage,
+      passwordSuccessMessage: clearPasswordSuccess ? null : passwordSuccessMessage ?? this.passwordSuccessMessage,
+      passwordErrorMessage: clearPasswordError ? null : passwordErrorMessage ?? this.passwordErrorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [profile, isLoading, isSaving, errorMessage, successMessage, passwordSuccessMessage, passwordErrorMessage];
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'business/legal_consent/boundary/legal_consent_bloc.dart';
 import 'business/legal_consent/control/legal_consent_repository.dart';
 import 'business/onboarding/boundary/onboarding_bloc.dart';
 import 'business/onboarding/control/onboarding_repository.dart';
+import 'business/profile/control/profile_repository.dart';
 
 void main() {
   runApp(const PlatformaTreningowaBootstrap());
@@ -23,6 +24,7 @@ class PlatformaTreningowaBootstrap extends StatelessWidget {
         RepositoryProvider(create: (_) => AuthRepository()),
         RepositoryProvider(create: (_) => LegalConsentRepository()),
         RepositoryProvider(create: (_) => OnboardingRepository()),
+        RepositoryProvider(create: (_) => ProfileRepository()),
       ],
       child: MultiBlocProvider(
         providers: [

--- a/mobile/test/business/profile/boundary/profile_bloc_test.dart
+++ b/mobile/test/business/profile/boundary/profile_bloc_test.dart
@@ -1,0 +1,58 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platforma_treningowa_mobile/business/profile/boundary/profile_bloc.dart';
+import 'package:platforma_treningowa_mobile/business/profile/control/profile_repository.dart';
+
+void main() {
+  group('ProfileBloc', () {
+    blocTest<ProfileBloc, ProfileState>(
+      'loads current profile',
+      build: () => ProfileBloc(ProfileRepository()),
+      act: (bloc) => bloc.add(const ProfileLoaded()),
+      wait: const Duration(milliseconds: 150),
+      expect: () => [
+        const ProfileState(isLoading: true),
+        predicate<ProfileState>((state) => state.isLoading == false && state.profile != null),
+      ],
+    );
+
+    blocTest<ProfileBloc, ProfileState>(
+      'updates editable profile fields',
+      build: () => ProfileBloc(ProfileRepository()),
+      seed: () => const ProfileState(profile: null),
+      act: (bloc) {
+        bloc.add(const ProfileUpdateSubmitted(
+          weight: '74.5',
+          trainingDays: ['MON', 'WED'],
+          goal: 'poprawić kondycję',
+          foodIntolerances: 'laktoza',
+          availableEquipment: ['gumy'],
+        ));
+      },
+      wait: const Duration(milliseconds: 150),
+      expect: () => [
+        const ProfileState(isSaving: true),
+        predicate<ProfileState>((state) =>
+            state.isSaving == false &&
+            state.profile?.weight == '74.5' &&
+            state.profile?.trainingDays.contains('MON') == true &&
+            state.successMessage == 'Profil zaktualizowany.'),
+      ],
+    );
+
+    blocTest<ProfileBloc, ProfileState>(
+      'returns password validation error for wrong current password',
+      build: () => ProfileBloc(ProfileRepository()),
+      act: (bloc) => bloc.add(const ProfilePasswordChangeSubmitted(
+        currentPassword: 'bad-password',
+        newPassword: 'newPassword123',
+        confirmNewPassword: 'newPassword123',
+      )),
+      wait: const Duration(milliseconds: 150),
+      expect: () => [
+        const ProfileState(isSaving: true),
+        predicate<ProfileState>((state) => state.isSaving == false && state.passwordErrorMessage == 'Nieprawidłowe aktualne hasło.'),
+      ],
+    );
+  });
+}

--- a/mobile/test/business/profile/boundary/profile_bloc_test.dart
+++ b/mobile/test/business/profile/boundary/profile_bloc_test.dart
@@ -43,6 +43,7 @@ void main() {
     blocTest<ProfileBloc, ProfileState>(
       'returns password validation error for wrong current password',
       build: () => ProfileBloc(ProfileRepository()),
+      seed: () => ProfileState.initial().copyWith(isLoading: false),
       act: (bloc) => bloc.add(const ProfilePasswordChangeSubmitted(
         currentPassword: 'bad-password',
         newPassword: 'newPassword123',

--- a/mobile/test/business/profile/boundary/profile_bloc_test.dart
+++ b/mobile/test/business/profile/boundary/profile_bloc_test.dart
@@ -43,7 +43,7 @@ void main() {
     blocTest<ProfileBloc, ProfileState>(
       'returns password validation error for wrong current password',
       build: () => ProfileBloc(ProfileRepository()),
-      seed: () => ProfileState.initial().copyWith(isLoading: false),
+      seed: () => const ProfileState(isLoading: false),
       act: (bloc) => bloc.add(const ProfilePasswordChangeSubmitted(
         currentPassword: 'bad-password',
         newPassword: 'newPassword123',

--- a/mobile/test/profile_screen_test.dart
+++ b/mobile/test/profile_screen_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platforma_treningowa_mobile/app/screens/profile_screen.dart';
+import 'package:platforma_treningowa_mobile/business/profile/boundary/profile_bloc.dart';
+import 'package:platforma_treningowa_mobile/business/profile/control/profile_repository.dart';
+
+void main() {
+  testWidgets('renders profile screen with edit and logout actions', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RepositoryProvider(
+          create: (_) => ProfileRepository(),
+          child: BlocProvider(
+            create: (context) => ProfileBloc(context.read<ProfileRepository>()),
+            child: ProfileScreen(
+              email: 'runner@example.com',
+              onBack: () {},
+              onLogout: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+
+    expect(find.text('Mój profil'), findsOneWidget);
+    expect(find.text('Edytuj profil'), findsOneWidget);
+    expect(find.text('Zmiana hasła'), findsOneWidget);
+    expect(find.text('Wyloguj'), findsOneWidget);
+  });
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -20,6 +20,7 @@ describe('App onboarding flows', () => {
     await user.click(screen.getByLabelText(/Akceptuję regulamin platformy/i));
     await user.click(screen.getByLabelText(/Oświadczam, że biorę odpowiedzialność/i));
     await user.click(screen.getByLabelText(/Akceptuję politykę prywatności/i));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Akceptuję i kontynuuję/i })).toBeEnabled());
     await user.click(screen.getByRole('button', { name: /Akceptuję i kontynuuję/i }));
 
     expect(await screen.findByText(/Ankieta startowa/i)).toBeInTheDocument();

--- a/web/src/pages/HomePage.tsx
+++ b/web/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { AuthForm } from '../components/AuthForm';
 import { LegalConsentCard } from '../components/LegalConsentCard';
 import { OnboardingCard } from '../components/OnboardingCard';
 import { ProfileSummaryCard } from '../components/ProfileSummaryCard';
+import { ProfilePage } from './ProfilePage';
 import { useHealthStatus } from '../hooks/useHealthStatus';
 import type { AuthResponse } from '../types/auth';
 import type { OnboardingProfile } from '../types/onboarding';
@@ -20,6 +21,7 @@ export function HomePage() {
   const [authResult, setAuthResult] = useState<AuthResponse | null>(null);
   const [acceptanceTimestamp, setAcceptanceTimestamp] = useState<string | null>(null);
   const [profile, setProfile] = useState<OnboardingProfile | null>(null);
+  const [showProfile, setShowProfile] = useState(false);
 
   const stage = !authResult ? 'auth' : !authResult.legalConsentsAccepted ? 'consents' : authResult.onboardingCompleted ? 'dashboard' : 'onboarding';
 
@@ -40,10 +42,18 @@ export function HomePage() {
     setAuthResult({ ...authResult, onboardingCompleted: false, redirectTo: '/onboarding' });
   };
 
+  const handleLogout = () => {
+    setAuthResult(null);
+    setProfile(null);
+    setAcceptanceTimestamp(null);
+    setShowProfile(false);
+    setMode('login');
+  };
+
   return <div className="container py-5">
-    <div className="row justify-content-center mb-5"><div className="col-lg-8 text-center"><span className="badge text-bg-success mb-3">Issue #4</span><h1 className="display-5 fw-bold">Platforma Treningowa</h1><p className="lead text-secondary">Rejestracja, zgody prawne i onboarding startowy dla nowych użytkowników.</p><p className="mb-0">Status backendu: <strong data-testid="health-status">{health?.status ?? 'Ładowanie...'}</strong></p></div></div>
-    {authResult && stage === 'dashboard' && <div className="alert alert-success" role="status">Zalogowano jako <strong>{authResult.email}</strong>. Redirect: <strong>{authResult.redirectTo}</strong>{acceptanceTimestamp && <span className="d-block mt-2">Zgody zaakceptowane: <strong>{acceptanceTimestamp}</strong></span>}</div>}
-    <div className="row g-4 align-items-start"><div className="col-lg-5">{stage === 'auth' && <><div className="d-flex gap-2 mb-3"><button className={`btn ${mode === 'register' ? 'btn-success' : 'btn-outline-success'}`} onClick={() => setMode('register')}>Rejestracja</button><button className={`btn ${mode === 'login' ? 'btn-success' : 'btn-outline-success'}`} onClick={() => setMode('login')}>Logowanie</button></div><AuthForm mode={mode} onAuthenticated={setAuthResult} /></>}{stage === 'consents' && authResult && <LegalConsentCard authResult={authResult} onCompleted={handleConsentsCompleted} />}{stage === 'onboarding' && authResult && <OnboardingCard authResult={authResult} onCompleted={handleOnboardingCompleted} />}{stage === 'dashboard' && profile && <ProfileSummaryCard profile={profile} onEdit={handleEdit} />}</div>
+    <div className="row justify-content-center mb-5"><div className="col-lg-8 text-center"><span className="badge text-bg-success mb-3">Issue #6</span><h1 className="display-5 fw-bold">Platforma Treningowa</h1><p className="lead text-secondary">Rejestracja, zgody prawne i onboarding startowy dla nowych użytkowników.</p><p className="mb-0">Status backendu: <strong data-testid="health-status">{health?.status ?? 'Ładowanie...'}</strong></p></div></div>
+    {authResult && stage === 'dashboard' && !showProfile && <div className="alert alert-success" role="status">Zalogowano jako <strong>{authResult.email}</strong>. Redirect: <strong>{authResult.redirectTo}</strong>{acceptanceTimestamp && <span className="d-block mt-2">Zgody zaakceptowane: <strong>{acceptanceTimestamp}</strong></span>}</div>}
+    <div className="row g-4 align-items-start"><div className="col-lg-5">{stage === 'auth' && <><div className="d-flex gap-2 mb-3"><button className={`btn ${mode === 'register' ? 'btn-success' : 'btn-outline-success'}`} onClick={() => setMode('register')}>Rejestracja</button><button className={`btn ${mode === 'login' ? 'btn-success' : 'btn-outline-success'}`} onClick={() => setMode('login')}>Logowanie</button></div><AuthForm mode={mode} onAuthenticated={setAuthResult} /></>}{stage === 'consents' && authResult && <LegalConsentCard authResult={authResult} onCompleted={handleConsentsCompleted} />}{stage === 'onboarding' && authResult && <OnboardingCard authResult={authResult} onCompleted={handleOnboardingCompleted} />}{stage === 'dashboard' && !showProfile && profile && <><ProfileSummaryCard profile={profile} onEdit={handleEdit} /><div className="d-flex gap-2 mt-3"><button className="btn btn-success" onClick={() => setShowProfile(true)}>Mój profil</button><button className="btn btn-outline-danger" onClick={handleLogout}>Wyloguj</button></div></>}{stage === 'dashboard' && showProfile && authResult && <><button className="btn btn-outline-secondary btn-sm mb-3" onClick={() => setShowProfile(false)}>Wróć do dashboardu</button><ProfilePage token={authResult.token} email={authResult.email} onLogout={handleLogout} /></>}</div>
       <div className="col-lg-7"><div className="row g-4">{features.map((feature) => <div key={feature.title} className="col-md-4 col-lg-12"><FeatureCard {...feature} /></div>)}</div></div></div>
   </div>;
 }

--- a/web/src/pages/ProfilePage.test.tsx
+++ b/web/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProfilePage } from './ProfilePage';
+import { seedAuthUser } from '../services/authService';
+
+describe('ProfilePage', () => {
+  const email = 'profile.test@example.com';
+  const token = `mock-token-${email}`;
+
+  beforeEach(() => {
+    seedAuthUser(email, 'password123', true, true);
+  });
+
+  it('displays user profile data', async () => {
+    render(<ProfilePage token={token} email={email} onLogout={() => {}} />);
+
+    expect(await screen.findByText(/profile.test@example.com/)).toBeInTheDocument();
+    expect(screen.getByText(/31/)).toBeInTheDocument();
+    expect(screen.getByText(/76.5 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/laktoza/)).toBeInTheDocument();
+  });
+
+  it('allows editing profile fields', async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage token={token} email={email} onLogout={() => {}} />);
+
+    await screen.findByText(/profile.test@example.com/);
+    await user.click(screen.getByRole('button', { name: 'Edytuj' }));
+
+    const weightInput = screen.getByLabelText('Waga (kg)');
+    await user.clear(weightInput);
+    await user.type(weightInput, '82');
+
+    await user.selectOptions(screen.getByLabelText('Cel'), 'schudnąć');
+    await user.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+    await waitFor(() => expect(screen.getByText(/Profil zaktualizowany/)).toBeInTheDocument());
+    expect(screen.getByText(/82 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/schudnąć/)).toBeInTheDocument();
+  });
+
+  it('changes password successfully', async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage token={token} email={email} onLogout={() => {}} />);
+
+    await screen.findByText(/profile.test@example.com/);
+    await user.click(screen.getByRole('button', { name: 'Zmień hasło' }));
+
+    await user.type(screen.getByLabelText('Aktualne hasło'), 'password123');
+    await user.type(screen.getByLabelText('Nowe hasło'), 'newpass456');
+    await user.type(screen.getByLabelText('Powtórz nowe hasło'), 'newpass456');
+    await user.click(screen.getByRole('button', { name: 'Zmień hasło' }));
+
+    await waitFor(() => expect(screen.getByText(/Hasło zostało zmienione/)).toBeInTheDocument());
+  });
+
+  it('shows error for wrong current password', async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage token={token} email={email} onLogout={() => {}} />);
+
+    await screen.findByText(/profile.test@example.com/);
+    await user.click(screen.getByRole('button', { name: 'Zmień hasło' }));
+
+    await user.type(screen.getByLabelText('Aktualne hasło'), 'wrongpassword');
+    await user.type(screen.getByLabelText('Nowe hasło'), 'newpass456');
+    await user.type(screen.getByLabelText('Powtórz nowe hasło'), 'newpass456');
+    await user.click(screen.getByRole('button', { name: 'Zmień hasło' }));
+
+    await waitFor(() => expect(screen.getByText(/Nieprawidłowe aktualne hasło/)).toBeInTheDocument());
+  });
+
+  it('calls onLogout when logout button clicked', async () => {
+    const onLogout = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfilePage token={token} email={email} onLogout={onLogout} />);
+
+    await screen.findByText(/profile.test@example.com/);
+    await user.click(screen.getByRole('button', { name: 'Wyloguj' }));
+
+    expect(onLogout).toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect } from 'react';
+import type { UserProfile, UpdateProfileRequest, ChangePasswordRequest } from '../types/profile';
+import { getUserProfile, updateUserProfile, changePassword } from '../services/authService';
+
+const dayLabels: Record<string, string> = { MON: 'Pon', TUE: 'Wt', WED: 'Śr', THU: 'Czw', FRI: 'Pt', SAT: 'Sob', SUN: 'Ndz' };
+const allDays = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+const goalOptions = ['schudnąć', 'poprawić kondycję', 'biegać szybciej', 'zacząć się ruszać', 'przygotowanie do zawodów'];
+const equipmentOptions = ['nic', 'hantle', 'gumy', 'siłownia'];
+
+export function ProfilePage({ token, email, onLogout }: { token: string; email: string; onLogout: () => void }) {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [weight, setWeight] = useState('');
+  const [trainingDays, setTrainingDays] = useState<string[]>([]);
+  const [goal, setGoal] = useState('');
+  const [foodIntolerances, setFoodIntolerances] = useState('');
+  const [availableEquipment, setAvailableEquipment] = useState<string[]>([]);
+
+  const [changingPassword, setChangingPassword] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmNewPassword, setConfirmNewPassword] = useState('');
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getUserProfile(token).then(setProfile).catch((e) => setError(e.message));
+  }, [token]);
+
+  const startEditing = () => {
+    if (!profile) return;
+    setWeight(profile.weight);
+    setTrainingDays([...profile.trainingDays]);
+    setGoal(profile.goal);
+    setFoodIntolerances(profile.foodIntolerances);
+    setAvailableEquipment([...profile.availableEquipment]);
+    setEditing(true);
+    setMessage(null);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const request: UpdateProfileRequest = {
+        weight: parseFloat(weight),
+        trainingDays,
+        goal,
+        foodIntolerances,
+        availableEquipment,
+      };
+      const updated = await updateUserProfile(token, request);
+      setProfile(updated);
+      setEditing(false);
+      setMessage('Profil zaktualizowany.');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Błąd zapisu.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChangePassword = async () => {
+    setPasswordSaving(true);
+    setPasswordError(null);
+    setPasswordMessage(null);
+    try {
+      const request: ChangePasswordRequest = { currentPassword, newPassword, confirmNewPassword };
+      await changePassword(token, request);
+      setPasswordMessage('Hasło zostało zmienione.');
+      setChangingPassword(false);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmNewPassword('');
+    } catch (e: unknown) {
+      setPasswordError(e instanceof Error ? e.message : 'Błąd zmiany hasła.');
+    } finally {
+      setPasswordSaving(false);
+    }
+  };
+
+  const toggleDay = (day: string) => {
+    setTrainingDays((prev) => prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]);
+  };
+
+  const toggleEquipment = (eq: string) => {
+    setAvailableEquipment((prev) => prev.includes(eq) ? prev.filter((e) => e !== eq) : [...prev, eq]);
+  };
+
+  if (!profile) return <div className="text-center py-4">{error ? <div className="alert alert-danger">{error}</div> : 'Ładowanie profilu...'}</div>;
+
+  return <div className="card shadow-sm">
+    <div className="card-body">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2 className="h5 mb-0">Profil użytkownika</h2>
+        <div className="d-flex gap-2">
+          {!editing && <button className="btn btn-outline-success btn-sm" onClick={startEditing}>Edytuj</button>}
+          <button className="btn btn-outline-danger btn-sm" onClick={onLogout}>Wyloguj</button>
+        </div>
+      </div>
+
+      {message && <div className="alert alert-success py-2">{message}</div>}
+      {error && <div className="alert alert-danger py-2">{error}</div>}
+
+      {!editing ? (
+        <div className="row g-3 small">
+          <div className="col-md-6"><strong>Email:</strong> {profile.email}</div>
+          <div className="col-md-6"><strong>Wiek:</strong> {profile.age}</div>
+          <div className="col-md-6"><strong>Płeć:</strong> {profile.sex}</div>
+          <div className="col-md-6"><strong>Waga:</strong> {profile.weight} kg</div>
+          <div className="col-md-6"><strong>Wzrost:</strong> {profile.height} cm</div>
+          <div className="col-md-6"><strong>Sylwetka:</strong> {profile.bodyType}</div>
+          <div className="col-md-6"><strong>Aktywność:</strong> {profile.activityHistory}</div>
+          <div className="col-md-6"><strong>Cel:</strong> {profile.goal}</div>
+          <div className="col-md-6"><strong>Dni treningowe:</strong> {profile.trainingDays.map((d) => dayLabels[d] || d).join(', ')}</div>
+          <div className="col-md-6"><strong>Sprzęt:</strong> {profile.availableEquipment.join(', ')}</div>
+          <div className="col-12"><strong>Nietolerancje:</strong> {profile.foodIntolerances || 'brak'}</div>
+        </div>
+      ) : (
+        <div>
+          <div className="mb-3">
+            <label htmlFor="profile-weight" className="form-label">Waga (kg)</label>
+            <input id="profile-weight" className="form-control" type="number" step="0.1" value={weight} onChange={(e) => setWeight(e.target.value)} />
+          </div>
+          <div className="mb-3">
+            <label className="form-label">Dni treningowe</label>
+            <div className="d-flex gap-1 flex-wrap">{allDays.map((day) => (
+              <button key={day} type="button" className={`btn btn-sm ${trainingDays.includes(day) ? 'btn-success' : 'btn-outline-secondary'}`} onClick={() => toggleDay(day)}>
+                {dayLabels[day]}
+              </button>
+            ))}</div>
+          </div>
+          <div className="mb-3">
+            <label htmlFor="profile-goal" className="form-label">Cel</label>
+            <select id="profile-goal" className="form-select" value={goal} onChange={(e) => setGoal(e.target.value)}>
+              <option value="">-- wybierz --</option>
+              {goalOptions.map((g) => <option key={g} value={g}>{g}</option>)}
+            </select>
+          </div>
+          <div className="mb-3">
+            <label htmlFor="profile-intolerances" className="form-label">Nietolerancje pokarmowe</label>
+            <textarea id="profile-intolerances" className="form-control" rows={2} value={foodIntolerances} onChange={(e) => setFoodIntolerances(e.target.value)} />
+          </div>
+          <div className="mb-3">
+            <label className="form-label">Dostępny sprzęt</label>
+            <div className="d-flex gap-1 flex-wrap">{equipmentOptions.map((eq) => (
+              <button key={eq} type="button" className={`btn btn-sm ${availableEquipment.includes(eq) ? 'btn-success' : 'btn-outline-secondary'}`} onClick={() => toggleEquipment(eq)}>
+                {eq}
+              </button>
+            ))}</div>
+          </div>
+          <div className="d-flex gap-2">
+            <button className="btn btn-success" disabled={saving} onClick={handleSave}>{saving ? 'Zapisywanie...' : 'Zapisz'}</button>
+            <button className="btn btn-outline-secondary" onClick={() => setEditing(false)}>Anuluj</button>
+          </div>
+        </div>
+      )}
+
+      <hr className="my-4" />
+
+      <h3 className="h6">Zmiana hasła</h3>
+      {passwordMessage && <div className="alert alert-success py-2">{passwordMessage}</div>}
+      {passwordError && <div className="alert alert-danger py-2">{passwordError}</div>}
+
+      {!changingPassword ? (
+        <button className="btn btn-outline-warning btn-sm" onClick={() => { setChangingPassword(true); setPasswordMessage(null); setPasswordError(null); }}>Zmień hasło</button>
+      ) : (
+        <div>
+          <div className="mb-2">
+            <label htmlFor="current-password" className="form-label">Aktualne hasło</label>
+            <input id="current-password" className="form-control" type="password" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} />
+          </div>
+          <div className="mb-2">
+            <label htmlFor="new-password" className="form-label">Nowe hasło</label>
+            <input id="new-password" className="form-control" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
+          </div>
+          <div className="mb-3">
+            <label htmlFor="confirm-new-password" className="form-label">Powtórz nowe hasło</label>
+            <input id="confirm-new-password" className="form-control" type="password" value={confirmNewPassword} onChange={(e) => setConfirmNewPassword(e.target.value)} />
+          </div>
+          <div className="d-flex gap-2">
+            <button className="btn btn-warning" disabled={passwordSaving} onClick={handleChangePassword}>{passwordSaving ? 'Zapisywanie...' : 'Zmień hasło'}</button>
+            <button className="btn btn-outline-secondary" onClick={() => setChangingPassword(false)}>Anuluj</button>
+          </div>
+        </div>
+      )}
+    </div>
+  </div>;
+}

--- a/web/src/services/authService.ts
+++ b/web/src/services/authService.ts
@@ -1,6 +1,7 @@
 import type { AuthRequest, AuthResponse } from '../types/auth';
 import type { LegalConsentState, SaveLegalConsentRequest } from '../types/legalConsent';
 import type { OnboardingProfile, SaveOnboardingProfileRequest } from '../types/onboarding';
+import type { UserProfile, UpdateProfileRequest, ChangePasswordRequest } from '../types/profile';
 
 type MockUser = {
   password: string;
@@ -100,6 +101,51 @@ export async function saveOnboardingProfile(token: string, request: SaveOnboardi
   return { ...user.profile, trainingDays: [...user.profile.trainingDays], availableEquipment: [...user.profile.availableEquipment] };
 }
 
+
+export async function getUserProfile(token: string): Promise<UserProfile> {
+  const user = registeredUsers.get(getEmailFromToken(token));
+  if (!user) throw new Error('Nie znaleziono użytkownika.');
+  const p = user.profile;
+  return delay({
+    email: getEmailFromToken(token),
+    age: p.age,
+    sex: p.sex,
+    weight: p.weight,
+    height: p.height,
+    bodyType: p.bodyType,
+    activityHistory: p.activityHistory,
+    trainingDays: [...p.trainingDays],
+    goal: p.goal,
+    targetDistance: p.targetDistance,
+    targetTime: p.targetTime,
+    foodIntolerances: p.foodIntolerances,
+    availableEquipment: [...p.availableEquipment],
+  });
+}
+
+export async function updateUserProfile(token: string, request: UpdateProfileRequest): Promise<UserProfile> {
+  const user = registeredUsers.get(getEmailFromToken(token));
+  if (!user) throw new Error('Nie znaleziono użytkownika.');
+  user.profile = {
+    ...user.profile,
+    weight: String(request.weight),
+    trainingDays: [...request.trainingDays],
+    goal: request.goal,
+    foodIntolerances: request.foodIntolerances,
+    availableEquipment: [...request.availableEquipment],
+  };
+  return getUserProfile(token);
+}
+
+export async function changePassword(token: string, request: ChangePasswordRequest): Promise<void> {
+  const user = registeredUsers.get(getEmailFromToken(token));
+  if (!user) throw new Error('Nie znaleziono użytkownika.');
+  if (user.password !== request.currentPassword) throw new Error('Nieprawidłowe aktualne hasło.');
+  if (request.newPassword !== request.confirmNewPassword) throw new Error('Nowe hasła muszą być identyczne.');
+  if (request.newPassword.length < 8) throw new Error('Nowe hasło musi mieć co najmniej 8 znaków.');
+  user.password = request.newPassword;
+  await delay(undefined);
+}
 
 export function seedAuthUser(email: string, password: string, onboardingCompleted: boolean, legalConsentsAccepted = true): void {
   registeredUsers.set(email.trim().toLowerCase(), {

--- a/web/src/types/profile.ts
+++ b/web/src/types/profile.ts
@@ -1,0 +1,29 @@
+export interface UserProfile {
+  email: string;
+  age: number | null;
+  sex: string;
+  weight: string;
+  height: string;
+  bodyType: string;
+  activityHistory: string;
+  trainingDays: string[];
+  goal: string;
+  targetDistance: string;
+  targetTime: string;
+  foodIntolerances: string;
+  availableEquipment: string[];
+}
+
+export interface UpdateProfileRequest {
+  weight: number;
+  trainingDays: string[];
+  goal: string;
+  foodIntolerances: string;
+  availableEquipment: string[];
+}
+
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  confirmNewPassword: string;
+}


### PR DESCRIPTION
## Summary
- add backend profile endpoints for view/update plus password change using existing onboarding data fields
- add web profile page with profile readback, editable supported fields, password change and logout
- add mobile profile scaffold with ECB/BLoC, profile screen, password change and logout wiring

## Verification
- [x] `cd backend && ./gradlew test`
- [x] `cd web && npm test && npm run build`
- [ ] `cd mobile && flutter test`
- [ ] `cd mobile && flutter analyze`

## Notes
- Flutter SDK is not installed on the current host, so the mobile profile flow was updated structurally but not executed locally.
- Web/mobile continue the repo's current mock-style client flow, while backend profile endpoints are implemented and tested.
- Scope kept to profile view/edit, password change and logout only.

Closes #6
